### PR TITLE
Using rustler-precompiled so that users don't have to install rust toolchain to compile the blake3 library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,75 @@
+name: Build precompiled NIFs
+
+env:
+  NIF_DIRECTORY: "native/blake3"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Just run on main branch if "native" path changed.
+      - "native/**"
+      # Also run if this file changes.
+      - ".github/workflows/release.yml"
+    tags:
+      - "*"
+
+jobs:
+  build_release:
+    name: NIF ${{ matrix.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        nif: ["2.16", "2.15"]
+        job:
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , use-cross: true }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , use-cross: true }
+          - { target: aarch64-unknown-linux-musl  , os: ubuntu-20.04 , use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-11      }
+          - { target: riscv64gc-unknown-linux-gnu , os: ubuntu-20.04 , use-cross: true }
+          - { target: x86_64-apple-darwin         , os: macos-11      }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04  }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , use-cross: true }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019  }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019  }
+
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v3
+
+    - name: Extract project version
+      shell: bash
+      run: |
+        # Get the project version from mix.exs
+        echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' mix.exs | head -n1)" >> $GITHUB_ENV
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        target: ${{ matrix.job.target }}
+
+    - name: Build the project
+      id: build-crate
+      uses: philss/rustler-precompiled-action@v1.0.0
+      with:
+        project-name: blake3
+        project-version: ${{ env.PROJECT_VERSION }}
+        target: ${{ matrix.job.target }}
+        nif-version: ${{ matrix.nif }}
+        use-cross: ${{ matrix.job.use-cross }}
+        project-dir: "native/blake3"
+
+    - name: Artifact upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.build-crate.outputs.file-name }}
+        path: ${{ steps.build-crate.outputs.file-path }}
+
+    - name: Publish archives and packages
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          ${{ steps.build-crate.outputs.file-path }}
+      if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   MIX_ENV: test
-
+  BLAKE3_BUILD: true
 jobs:
   test:
     name: OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }} / Rust ${{ matrix.rust }}

--- a/lib/blake3/native.ex
+++ b/lib/blake3/native.ex
@@ -4,8 +4,28 @@ defmodule Blake3.Native do
   This module doesn't need to be called direcly.
   """
 
-  use Rustler,
-    otp_app: :blake3
+  mix_config = Mix.Project.config()
+  version = mix_config[:version]
+  github_url = mix_config[:package][:links]["GitHub"]
+
+  use RustlerPrecompiled,
+    otp_app: :blake3,
+    crate: "blake3",
+    base_url: "#{github_url}/releases/download/v#{version}",
+    force_build: System.get_env("BLAKE3_BUILD") in ["1", "true"],
+    version: version,
+    targets: ~w(
+    arm-unknown-linux-gnueabihf
+    aarch64-apple-darwin
+    aarch64-unknown-linux-gnu
+    aarch64-unknown-linux-musl
+    riscv64gc-unknown-linux-gnu
+    x86_64-apple-darwin
+    x86_64-pc-windows-gnu
+    x86_64-pc-windows-msvc
+    x86_64-unknown-linux-gnu
+    x86_64-unknown-linux-musl
+  )s
 
   def hash(_str), do: error()
   def new(), do: error()

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,13 @@
 defmodule MixBlake3.Project do
   use Mix.Project
 
+  @source_url "https://github.com/Thomas-Jean/blake3"
+  @version "1.0.2"
+
   def project do
     [
       app: :blake3,
-      version: "1.0.2",
+      version: @version,
       elixir: "~> 1.13",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
@@ -21,15 +24,24 @@ defmodule MixBlake3.Project do
   defp package() do
     [
       description: "Elixir binding for the Rust Blake3 implementation",
-      files: ["lib", "native", ".formatter.exs", "README*", "LICENSE*", "mix.exs"],
+      files: [
+        "lib",
+        "native",
+        ".formatter.exs",
+        "README*",
+        "LICENSE*",
+        "mix.exs",
+        "checksum-*.exs"
+      ],
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/Thomas-Jean/blake3"}
+      links: %{"GitHub" => @source_url}
     ]
   end
 
   defp deps do
     [
-      {:rustler, "~> 0.30"},
+      {:rustler_precompiled, "~> 0.7.0"},
+      {:rustler, "~> 0.30", optional: true},
       {:ex_doc, "~> 0.21", only: [:dev, :test], runtime: false}
     ]
   end
@@ -38,7 +50,7 @@ defmodule MixBlake3.Project do
     [
       extras: ["README.md"],
       main: "readme",
-      source_url: "https://github.com/Thomas-Jean/blake3"
+      source_url: @source_url
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "castore": {:hex, :castore, "1.0.5", "9eeebb394cc9a0f3ae56b813459f990abb0a3dedee1be6b27fdb50301930502f", [:mix], [], "hexpm", "8d7c597c3e4a64c395980882d4bca3cebb8d74197c590dc272cfd3b6a6310578"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.31", "a93921cdc6b9b869f519213d5bc79d9e218ba768d7270d46fdcf1c01bacff9e2", [:mix], [], "hexpm", "317d367ee0335ef037a87e46c91a2269fef6306413f731e8ec11fc45a7efd059"},
   "ex_doc": {:hex, :ex_doc, "0.29.4", "6257ecbb20c7396b1fe5accd55b7b0d23f44b6aa18017b415cb4c2b91d997729", [:mix], [{:earmark_parser, "~> 1.4.31", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "2c6699a737ae46cb61e4ed012af931b57b699643b24dabe2400a8168414bc4f5"},
@@ -8,5 +9,6 @@
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.3.0", "9e18a119d9efc3370a3ef2a937bf0b24c088d9c4bf0ba9d7c3751d49d347d035", [:mix], [], "hexpm", "7977f183127a7cbe9346981e2f480dc04c55ffddaef746bd58debd566070eef8"},
   "rustler": {:hex, :rustler, "0.30.0", "cefc49922132b072853fa9b0ca4dc2ffcb452f68fb73b779042b02d545e097fb", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}, {:toml, "~> 0.6", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm", "9ef1abb6a7dda35c47cfc649e6a5a61663af6cf842a55814a554a84607dee389"},
+  "rustler_precompiled": {:hex, :rustler_precompiled, "0.7.1", "ecadf02cc59a0eccbaed6c1937303a5827fbcf60010c541595e6d3747d3d0f9f", [:mix], [{:castore, "~> 0.1 or ~> 1.0", [hex: :castore, repo: "hexpm", optional: false]}, {:rustler, "~> 0.23", [hex: :rustler, repo: "hexpm", optional: true]}], "hexpm", "b9e4657b99a1483ea31502e1d58c464bedebe9028808eda45c3a429af4550c66"},
   "toml": {:hex, :toml, "0.7.0", "fbcd773caa937d0c7a02c301a1feea25612720ac3fa1ccb8bfd9d30d822911de", [:mix], [], "hexpm", "0690246a2478c1defd100b0c9b89b4ea280a22be9a7b313a8a058a2408a2fa70"},
 }

--- a/native/blake3/.cargo/config
+++ b/native/blake3/.cargo/config
@@ -8,3 +8,25 @@ rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
 ]
+# See https://github.com/rust-lang/rust/issues/59302
+[target.x86_64-unknown-linux-musl]
+rustflags = [
+  "-C", "target-feature=-crt-static"
+]
+
+# Same as above
+[target.aarch64-unknown-linux-musl]
+rustflags = [
+  "-C", "target-feature=-crt-static"
+]
+
+#  Libatomic is needed for 32 bits ARM.
+#  See: https://github.com/philss/rustler_precompiled/issues/53
+[target.arm-unknown-linux-gnueabihf]
+rustflags = [
+  "-l", "dylib=atomic"
+]
+
+# Provides a small build size, but takes more time to build.
+[profile.release]
+lto = true


### PR DESCRIPTION
Currently if we have to use the `blake3` library then the host needs to have rust toolchain as a prerequisite. Due to this we need to install rust in the dockerfiles etc. We can use [rustler-precompiled](https://github.com/philss/rustler_precompiled), such that the nif will be already build (on most rust supported platforms) and the artificats will be uploaded already, and we basically just download the corresponding nif needed for the host.

This PR is kind of a draft, because the major work happens in CI. Things we have to do now are,
- [Configure Github actions](https://hexdocs.pm/rustler_precompiled/precompilation_guide.html#configure-github-actions).

- We could add in the readme section that, to force local compilation we need to set the env to `BLAKE_BUILD=1`. This is for those who wants to contribute.

- [The release flow](https://hexdocs.pm/rustler_precompiled/precompilation_guide.html#the-release-flow)
    - I have added a `build.yml` which does the building , uploading etc. This could be opinionated so i have just separated it from the rest, we could maybe merge it with the `release.yml`. Also In the release flow doc, there is part on generating checksum which is mandatory for hex. So this could be also added to `release.yml`.

Since i needed this urgently i have tried adding this to a [blake3 clone project](https://github.com/madclaws/blake3-precompiled) and it worked !!. Other references i have used are,

- [rustler-precompiled blog](https://dashbit.co/blog/rustler-precompiled)
- [resvg](https://github.com/mrdotb/resvg_nif) already uses this.

Glad to help, if any doubts :+1: 
